### PR TITLE
fix: dist folder ignored at publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nightfall-sdk",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "SDK for interacting with Nightfall",
   "keywords": [
     "nightfall",
@@ -15,8 +15,7 @@
   },
   "types": "./dist/types/user/index.d.ts",
   "files": [
-    "./dist/**/*",
-    "./CHANGELOG.md"
+    "dist/**/*"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

Dir `dist` not included in published package.

## Does this close any currently open issues?

No

## What commands can I run to test the change? 

```
npm run build && npm publish --dry-run
```
