### PR TITLE
Log obfuscated valid user on creation

### DIFF
--- a/__tests__/unit/utils/shallowObfuscate.test.ts
+++ b/__tests__/unit/utils/shallowObfuscate.test.ts
@@ -1,0 +1,39 @@
+import { shallowObfuscate } from "../../../libs/utils";
+
+describe("shallowObfuscate", () => {
+  const obj = {
+    a: "a",
+    b: "b",
+  };
+
+  test("obfuscates single key", () => {
+    const result = {
+      a: "***",
+      b: "b",
+    };
+
+    expect(shallowObfuscate(obj, ["a"])).toEqual(result);
+  });
+
+  test("obfuscates multiple keys", () => {
+    const result = {
+      a: "***",
+      b: "***",
+    };
+
+    expect(shallowObfuscate(obj, ["a", "b"])).toEqual(result);
+  });
+
+  test("creates a shallow copy when keys are not provided", () => {
+    const result = {
+      a: "a",
+      b: "b",
+    };
+
+    expect(shallowObfuscate(obj, [])).not.toBe(result);
+    expect(shallowObfuscate(obj, [])).toEqual({
+      a: "a",
+      b: "b",
+    });
+  });
+});

--- a/libs/user/user.ts
+++ b/libs/user/user.ts
@@ -52,6 +52,7 @@ import type {
 } from "./types";
 import type { Commitment, NightfallZkpKeys } from "../nightfall/types";
 import type { NightfallSDKTransactionReceipt } from "../transactions/types";
+import { shallowObfuscate } from "../utils";
 
 class UserFactory {
   static async create(options: UserFactoryCreate) {
@@ -60,7 +61,11 @@ class UserFactory {
     // Validate and format options
     const { error, value } = createOptions.validate(options);
     isInputValid(error);
-    // TODO log value with obfuscation
+
+    logger.debug(
+      shallowObfuscate(value, ["nightfallMnemonic", "ethereumPrivateKey"]),
+      "Valid user",
+    );
 
     const {
       clientApiUrl,

--- a/libs/utils/index.ts
+++ b/libs/utils/index.ts
@@ -1,5 +1,12 @@
 import { NightfallSdkError } from "./error";
 import { logger } from "./logger";
+import { shallowObfuscate } from "./shallowObfuscate";
 import { randomL2TokenAddress, randomSalt } from "./random";
 
-export { logger, NightfallSdkError, randomL2TokenAddress, randomSalt };
+export {
+  logger,
+  NightfallSdkError,
+  randomL2TokenAddress,
+  randomSalt,
+  shallowObfuscate,
+};

--- a/libs/utils/shallowObfuscate.ts
+++ b/libs/utils/shallowObfuscate.ts
@@ -1,0 +1,11 @@
+export const shallowObfuscate = <T>(
+  data: T,
+  obfuscatedKeys: (keyof T)[],
+): Partial<T> =>
+  obfuscatedKeys.reduce(
+    (acc, key) => ({
+      ...acc,
+      [key]: "***",
+    }),
+    data,
+  );


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

Log obfuscated valid user on creation.

## What commands can I run to test the change? 

```
cd __tests__/unit/utils
npx jest shallowObfuscate.test.ts
```

## Any other comments?

If needed, this helper function can be easily modified to handle deep obfuscation, but for now thats not needed.