### PR TITLE
chore: treat l2 addresses as custom erc

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ Run a local Client by [running the Nightfall project](https://github.com/EYBlock
 ./bin/start-nightfall -g -d
 ```
 
-When running Nightfall locally, a local Proposer application is also needed to produce blocks:
+When running Nightfall locally, a local Proposer is also needed to produce blocks:
 
 ```bash
-# From Nightfall dir root
-./bin/start-apps
+# From terminal, after starting Nightfall
+curl -k -X POST -d "url=http://optimist" http://localhost:8081/proposer/register
+# FYI this is how to require proposer to produce L2 block
+curl -k -X POST http://localhost:8081/block/make-now
 ```
 
 ## Play with the SDK repository
@@ -142,7 +144,6 @@ Learn how to:
 
 :bulb: Balance on Nightfall will update as soon as funds settle, i.e. soon as an L2 block is produced.
 
-
 ```bash
 npm run eg:[network]:deposit
 ```
@@ -158,7 +159,6 @@ Learn how to:
 - Check spent balances not yet included in an L2 block
 
 :bulb: For making a transfer an already existing account in L2 with balance is required. This can be achieved by saving the mnemonic used for previous deposits and adding it to the .env file.
-
 
 ```bash
 npm run eg:[network]:transfer

--- a/__tests__/integration/nightfall/keys.test.ts
+++ b/__tests__/integration/nightfall/keys.test.ts
@@ -1,7 +1,7 @@
 import { Client } from "../../../libs/client";
 import { createZkpKeysAndSubscribeToIncomingKeys } from "../../../libs/nightfall";
 
-const CLIENT_API_URL = process.env.APP_CLIENT_API_URL;
+const CLIENT_API_URL = process.env.APP_CLIENT_API_URL as string;
 
 describe("Create Zero-knowledge proof keys and subscribe to incoming keys", () => {
   let mnemonic: undefined | string;
@@ -28,16 +28,16 @@ describe("Create Zero-knowledge proof keys and subscribe to incoming keys", () =
       nightfallMnemonic: mnemonic,
       zkpKeys: {
         compressedZkpPublicKey:
-          "0x00781eab9bd94da3eb84c7a1b085f162f5eb58f9c189efef788a5176982a07e1",
+          "0x1b28c15d62dd0e837a227e7644c20cd4f96f7d4edca3bd5e544b24dfaabf9c8b",
         nullifierKey:
-          "0x1ec80c50b816fff74890a5d08bc95c1c749d955201b8a9ada0f99a117b8ccc8a",
+          "0xef9123f8fa4046940a79b6915e11ebe84f5c7ae60023423f7a0f47b96d32a34",
         rootKey:
-          "0x2366fc5530da8bc6618f01b2ac8fee17489cdef28ee8c21a0b945ba883d0da7c",
+          "0x1765c51ea2da66a362a6507dd64572694d6b31fbc1524c7b8e2bed5e514c979a",
         zkpPrivateKey:
-          "0xd9f1e813a2c10559620ad3fba2050c13898d1250776f27b9e7f35de5f973788",
+          "0x668d89fd55437fe7440de835599a75d70c846c0cb40aacfdd0af02d44cb5a6a",
         zkpPublicKey: [
-          "0x39cf22690edcc4d25eb1121a8d583e566b03463ef2defc8703670878ddca0ce",
-          "0x781eab9bd94da3eb84c7a1b085f162f5eb58f9c189efef788a5176982a07e1",
+          "0x28dbdb83efde29f2757add6807cbb301831fabfb89a85d3f69beb5f6bc78ba2",
+          "0x1b28c15d62dd0e837a227e7644c20cd4f96f7d4edca3bd5e544b24dfaabf9c8b",
         ],
       },
     };

--- a/__tests__/unit/client/client.test.ts
+++ b/__tests__/unit/client/client.test.ts
@@ -9,16 +9,16 @@ describe("Client", () => {
   const client = new Client(dummyUrl);
   const zkpKeys = {
     compressedZkpPublicKey:
-      "0x00781eab9bd94da3eb84c7a1b085f162f5eb58f9c189efef788a5176982a07e1",
+      "0x1b28c15d62dd0e837a227e7644c20cd4f96f7d4edca3bd5e544b24dfaabf9c8b",
     nullifierKey:
-      "0x1ec80c50b816fff74890a5d08bc95c1c749d955201b8a9ada0f99a117b8ccc8a",
+      "0xef9123f8fa4046940a79b6915e11ebe84f5c7ae60023423f7a0f47b96d32a34",
     rootKey:
-      "0x2366fc5530da8bc6618f01b2ac8fee17489cdef28ee8c21a0b945ba883d0da7c",
+      "0x1765c51ea2da66a362a6507dd64572694d6b31fbc1524c7b8e2bed5e514c979a",
     zkpPrivateKey:
-      "0xd9f1e813a2c10559620ad3fba2050c13898d1250776f27b9e7f35de5f973788",
+      "0x668d89fd55437fe7440de835599a75d70c846c0cb40aacfdd0af02d44cb5a6a",
     zkpPublicKey: [
-      "0x39cf22690edcc4d25eb1121a8d583e566b03463ef2defc8703670878ddca0ce",
-      "0x781eab9bd94da3eb84c7a1b085f162f5eb58f9c189efef788a5176982a07e1",
+      "0x28dbdb83efde29f2757add6807cbb301831fabfb89a85d3f69beb5f6bc78ba2",
+      "0x1b28c15d62dd0e837a227e7644c20cd4f96f7d4edca3bd5e544b24dfaabf9c8b",
     ],
   };
 

--- a/examples/scripts/l2TokenisationBurning.ts
+++ b/examples/scripts/l2TokenisationBurning.ts
@@ -29,7 +29,7 @@ const main = async () => {
 
     // # 3 Burn
     const { txHashL2 } = await user.burnL2Token({
-      tokenAddress: commitmentsToBurn[0].ercAddress,
+      tokenContractAddress: commitmentsToBurn[0].ercAddress,
       value: String(commitmentsToBurn[0].balance),
       tokenId: commitmentsToBurn[0].tokenId,
       feeWei: config.feeWei,

--- a/examples/scripts/l2TokenisationMinting.ts
+++ b/examples/scripts/l2TokenisationMinting.ts
@@ -15,10 +15,10 @@ const main = async () => {
     });
 
     // # 2 Mint token within L2
-    const tokenAddress = await randomL2TokenAddress();
+    const tokenContractAddress = await randomL2TokenAddress();
     const salt = await randomSalt();
     const { txHashL2 } = await user.mintL2Token({
-      tokenAddress,
+      tokenContractAddress,
       value: config.value,
       tokenId: config.tokenId,
       salt, // optional

--- a/libs/tokens/constants.ts
+++ b/libs/tokens/constants.ts
@@ -7,7 +7,7 @@ export const ERC20 = "ERC20";
 export const ERC721 = "ERC721";
 export const ERC1155 = "ERC1155";
 export const ERC165 = "ERC165";
-export const CUSTOM_ERC = "custom";
+export const ERC_CUSTOM = "ERC_CUSTOM";
 
 export const ERC721_INTERFACE_ID = "0x80ac58cd";
 export const ERC1155_INTERFACE_ID = "0xd9b67a26";

--- a/libs/tokens/constants.ts
+++ b/libs/tokens/constants.ts
@@ -7,5 +7,7 @@ export const ERC20 = "ERC20";
 export const ERC721 = "ERC721";
 export const ERC1155 = "ERC1155";
 export const ERC165 = "ERC165";
+export const CUSTOM_ERC = "custom";
 
 export const ERC721_INTERFACE_ID = "0x80ac58cd";
+export const ERC1155_INTERFACE_ID = "0xd9b67a26";

--- a/libs/tokens/token.ts
+++ b/libs/tokens/token.ts
@@ -9,7 +9,7 @@ import erc721Abi from "./abis/ERC721.json";
 import erc1155Abi from "./abis/ERC1155.json";
 import type { AbiItem } from "web3-utils";
 import {
-  CUSTOM_ERC,
+  ERC_CUSTOM,
   ERC20,
   ERC721,
   ERC1155,
@@ -59,7 +59,7 @@ export async function whichTokenStandard(
     }
   } catch {
     logger.debug("Assume interface Nightfall native tx");
-    return CUSTOM_ERC;
+    return ERC_CUSTOM;
   }
 }
 
@@ -109,7 +109,7 @@ class Token {
     this.contractAddress = options.contractAddress;
     this.ercStandard = options.ercStandard.toUpperCase();
 
-    if (this.ercStandard !== CUSTOM_ERC) {
+    if (this.ercStandard !== ERC_CUSTOM) {
       this.setTokenContract();
     }
   }

--- a/libs/transactions/helpers/prepareTokenValueTokenId.ts
+++ b/libs/transactions/helpers/prepareTokenValueTokenId.ts
@@ -11,10 +11,12 @@ import { logger } from "../../utils";
  * Create an instance of Token
  * Convert value to Wei if needed
  *
- * @function whichTokenStandard
+ * @function prepareTokenValueTokenId
  * @param {string} contractAddress
+ * @param {string} value
+ * @param {string} tokenId
  * @param {Web3} web3
- * @returns {string} "ERC20" | "ERC721" | "ERC1155"
+ * @returns {Promise<*>}
  */
 export async function prepareTokenValueTokenId(
   contractAddress: string,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nightfall-sdk",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "SDK for interacting with Nightfall",
   "keywords": [
     "nightfall",


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

- Adjust flow so that Nightfall native transactions can happen (L2 native tokens will be detected as "erc - custom")
- Adjust "creation" of L1 tx as per NIghtfall implementation
- Small updates and fixes to tests, scripts, docs

## Does this close any currently open issues?

Closes #20 

## Any other comments?

Verified exports. The following are available (should be) from NPM package - see [index.ts](https://github.com/NightfallRollup/nightfall-sdk/blob/master/libs/index.ts):

```ts
export {
  UserFactory,
  createZkpKeys,
  getContractAddress,
  NightfallSdkError,
  randomL2TokenAddress,
  randomSalt,
};
```

FYI Although SDK can work without Ethereum Private Key, SDK will interpret this as if it wanted to interact with MetaMask. We can think of alternatives, but for now should be fine.