### PR TITLE
Get transactions info from client

### DIFF
--- a/examples/scripts/appConfig.ts
+++ b/examples/scripts/appConfig.ts
@@ -1,5 +1,8 @@
 export const config = {
   clientApiUrl: process.env.APP_CLIENT_API_URL || "http://localhost:8080",
+  clientApiBpUrl: process.env.APP_CLIENT_API_BP_URL || "http://localhost:3020",
+  clientApiTxUrl: process.env.APP_CLIENT_API_TX_URL || "http://localhost:3010",
+  optimistApiTxUrl: process.env.APP_OPTIMIST_API_TX_URL || "http://localhost:3030",
   nightfallMnemonic: process.env.APP_NIGHTFALL_MNEMONIC,
   ethereumPrivateKey: process.env.APP_ETH_PRIVATE_KEY,
   blockchainWsUrl: process.env.APP_BLOCKCHAIN_WEBSOCKET_URL,

--- a/examples/scripts/balances.ts
+++ b/examples/scripts/balances.ts
@@ -9,6 +9,8 @@ const main = async () => {
     user = await UserFactory.create({
       blockchainWsUrl: config.blockchainWsUrl,
       clientApiUrl: config.clientApiUrl,
+      clientApiBpUrl: config.clientApiBpUrl,
+      clientApiTxUrl: config.clientApiTxUrl,
       ethereumPrivateKey: config.ethereumPrivateKey,
       nightfallMnemonic: config.nightfallMnemonic,
     });

--- a/examples/scripts/commitmentsExport.ts
+++ b/examples/scripts/commitmentsExport.ts
@@ -8,6 +8,8 @@ const main = async () => {
     user = await UserFactory.create({
       blockchainWsUrl: config.blockchainWsUrl,
       clientApiUrl: config.clientApiUrl,
+      clientApiBpUrl: config.clientApiBpUrl,
+      clientApiTxUrl: config.clientApiTxUrl,
       ethereumPrivateKey: config.ethereumPrivateKey,
       nightfallMnemonic: config.nightfallMnemonic,
     });

--- a/examples/scripts/commitmentsImport.ts
+++ b/examples/scripts/commitmentsImport.ts
@@ -8,6 +8,8 @@ const main = async () => {
     user = await UserFactory.create({
       blockchainWsUrl: config.blockchainWsUrl,
       clientApiUrl: config.clientApiUrl,
+      clientApiBpUrl: config.clientApiBpUrl,
+      clientApiTxUrl: config.clientApiTxUrl,
       ethereumPrivateKey: config.ethereumPrivateKey,
       nightfallMnemonic: config.nightfallMnemonic,
     });

--- a/examples/scripts/l2TokenisationBurning.ts
+++ b/examples/scripts/l2TokenisationBurning.ts
@@ -9,6 +9,8 @@ const main = async () => {
     user = await UserFactory.create({
       blockchainWsUrl: config.blockchainWsUrl,
       clientApiUrl: config.clientApiUrl,
+      clientApiBpUrl: config.clientApiBpUrl,
+      clientApiTxUrl: config.clientApiTxUrl,
       ethereumPrivateKey: config.ethereumPrivateKey,
       nightfallMnemonic: config.nightfallMnemonic,
     });

--- a/examples/scripts/l2TokenisationMinting.ts
+++ b/examples/scripts/l2TokenisationMinting.ts
@@ -8,10 +8,12 @@ const main = async () => {
   try {
     // # 1 Create an instance of User
     user = await UserFactory.create({
-      clientApiUrl: config.clientApiUrl,
-      nightfallMnemonic: config.nightfallMnemonic,
-      ethereumPrivateKey: config.ethereumPrivateKey,
       blockchainWsUrl: config.blockchainWsUrl,
+      clientApiUrl: config.clientApiUrl,
+      clientApiBpUrl: config.clientApiBpUrl,
+      clientApiTxUrl: config.clientApiTxUrl,
+      ethereumPrivateKey: config.ethereumPrivateKey,
+      nightfallMnemonic: config.nightfallMnemonic,
     });
 
     // # 2 Mint token within L2

--- a/examples/scripts/transactionsInfo.ts
+++ b/examples/scripts/transactionsInfo.ts
@@ -1,0 +1,123 @@
+import axios from "axios";
+import { UserFactory, createZkpKeys } from "../../libs";
+import { config } from "./appConfig";
+
+const makeBlock = async () => {
+  // TODO: For now, i am assuming this works only on localhost with optimist workers, not on testnet
+  await axios.post(`${config.optimistApiTxUrl}/block/make-now`);
+};
+
+// Script
+const main = async () => {
+  let user;
+  try {
+    // # 1 Create an instance of User
+    user = await UserFactory.create({
+      blockchainWsUrl: config.blockchainWsUrl,
+      clientApiUrl: config.clientApiUrl,
+      clientApiBpUrl: config.clientApiBpUrl,
+      clientApiTxUrl: config.clientApiTxUrl,
+      ethereumPrivateKey: config.ethereumPrivateKey,
+      nightfallMnemonic: config.nightfallMnemonic,
+    });
+
+    let txHashL1;
+    let txHashL2;
+
+    // # 4 Make deposit
+    ({ txHashL1, txHashL2 } = await user.makeDeposit({
+      tokenContractAddress: config.tokenContractAddress,
+      value: config.value,
+      tokenId: config.tokenId,
+      feeWei: config.feeWei,
+    }));
+    console.log(">>>>> Transaction hash L1", txHashL1);
+    console.log(">>>>> Transaction hash L2", txHashL2);
+
+    // # 5 [OPTIONAL] You can check the transaction hash
+    // TODO
+
+    // # 6 [OPTIONAL] You can check deposits that are not yet in Nightfall
+    const pendingDeposits = await user.checkPendingDeposits({
+      tokenContractAddresses: [config.tokenContractAddress],
+    });
+    console.log(">>>>> Pending balances for deposited token", pendingDeposits);
+
+    // # 7 [EXTRA] Check that L1 tx was mined before closing the websocket in `finally` clause
+    let isTxL1Mined = await user.web3Websocket.web3.eth.getTransactionReceipt(
+      txHashL1,
+    );
+    while (isTxL1Mined === null) {
+      console.log(">>>>> Waiting for L1 transaction to be mined..");
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+      isTxL1Mined = await user.web3Websocket.web3.eth.getTransactionReceipt(
+        txHashL1,
+      );
+    }    
+
+    // # 2 Make transfer
+    // For this example, we generate a L2 address to receive the transfer
+    const { zkpKeys } = await createZkpKeys(config.clientApiUrl);
+
+    const isOffChain = true;
+    ({ txHashL1, txHashL2 } = await user.makeTransfer({
+      tokenContractAddress: config.tokenContractAddress,
+      value: config.value,
+      tokenId: config.tokenId,
+      recipientNightfallAddress: zkpKeys.compressedZkpPublicKey,
+      isOffChain,
+      feeWei: config.feeWei,
+    }));
+    console.log(
+      ">>>>> Transaction hash L1 (`undefined` if off-chain)",
+      txHashL1,
+    );
+    console.log(">>>>> Transaction hash L2", txHashL2);
+
+    // # 3 [OPTIONAL] You can check the transaction hash
+    // TODO
+
+    // # 4 [OPTIONAL] You can check transfers that are not yet in a block
+    const pendingTransfers =
+      await user.checkPendingTransfersAndWithdrawals();
+    console.log(">>>>> Pending balances", pendingTransfers);
+
+    // # 5 [EXTRA] Check that L1 tx was mined before closing the websocket in `finally` clause
+    if (!isOffChain) {
+      let isTxL1Mined =
+        await user.web3Websocket.web3.eth.getTransactionReceipt(txHashL1);
+      while (isTxL1Mined === null) {
+        console.log(">>>>> Waiting for L1 transaction to be mined..");
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+        isTxL1Mined =
+          await user.web3Websocket.web3.eth.getTransactionReceipt(
+            txHashL1,
+          );
+      }
+    } else {
+      // # 5 [EXTRA] Wait for a block to be mined
+      console.log(">>>>> Making block manually..");
+      await makeBlock();
+      // # 6 Get Nightfall transactions info by transaction hashes (only transactions in block return info)
+      let transactionsInfo = await user.getTransactionsInfo({
+        transactionHashes: [txHashL2],
+      });
+      while (transactionsInfo.length === 0) {
+        console.log(">>>>> Waiting for L2 transaction to be mined..");
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+        transactionsInfo = await user.getTransactionsInfo({
+          transactionHashes: [txHashL2],
+        });
+      }
+      console.log(">>>>> transactions info", transactionsInfo);       
+    }
+  } catch (error) {
+    console.log(error);
+    process.exit(1);
+  } finally {
+    user.close();
+    console.log(">>>>> Bye bye");
+  }
+};
+
+main();

--- a/examples/scripts/txDeposit.ts
+++ b/examples/scripts/txDeposit.ts
@@ -9,10 +9,12 @@ const main = async () => {
     // # 1 Create an instance of User (bip39 mnemonic is optional)
     // Will generate a new bip39 mnemonic if you don't pass one and derive a new set of zero-knowledge proof keys
     user = await UserFactory.create({
-      clientApiUrl: config.clientApiUrl,
-      nightfallMnemonic: config.nightfallMnemonic,
-      ethereumPrivateKey: config.ethereumPrivateKey,
       blockchainWsUrl: config.blockchainWsUrl,
+      clientApiUrl: config.clientApiUrl,
+      clientApiBpUrl: config.clientApiBpUrl,
+      clientApiTxUrl: config.clientApiTxUrl,
+      ethereumPrivateKey: config.ethereumPrivateKey,
+      nightfallMnemonic: config.nightfallMnemonic,
     });
 
     // # 2 [OPTIONAL] If you did not pass a mnemonic, make sure to retrieve it

--- a/examples/scripts/txTransfer.ts
+++ b/examples/scripts/txTransfer.ts
@@ -8,10 +8,12 @@ const main = async () => {
   try {
     // # 1 Create an instance of User
     userSender = await UserFactory.create({
+      blockchainWsUrl: config.blockchainWsUrl,
       clientApiUrl: config.clientApiUrl,
+      clientApiBpUrl: config.clientApiBpUrl,
+      clientApiTxUrl: config.clientApiTxUrl,
       ethereumPrivateKey: config.ethereumPrivateKey,
       nightfallMnemonic: config.nightfallMnemonic,
-      blockchainWsUrl: config.blockchainWsUrl,
     });
 
     // # 2 Make transfer

--- a/examples/scripts/txWithdrawal.ts
+++ b/examples/scripts/txWithdrawal.ts
@@ -7,10 +7,12 @@ const main = async () => {
   try {
     // # 1 Create an instance of User
     user = await UserFactory.create({
-      clientApiUrl: config.clientApiUrl,
-      nightfallMnemonic: config.nightfallMnemonic,
       blockchainWsUrl: config.blockchainWsUrl,
+      clientApiUrl: config.clientApiUrl,
+      clientApiBpUrl: config.clientApiBpUrl,
+      clientApiTxUrl: config.clientApiTxUrl,
       ethereumPrivateKey: config.ethereumPrivateKey,
+      nightfallMnemonic: config.nightfallMnemonic,
     });
 
     // # 2 Make withdrawal

--- a/examples/scripts/txWithdrawalFinalise.ts
+++ b/examples/scripts/txWithdrawalFinalise.ts
@@ -8,6 +8,8 @@ const main = async () => {
     user = await UserFactory.create({
       blockchainWsUrl: config.blockchainWsUrl,
       clientApiUrl: config.clientApiUrl,
+      clientApiBpUrl: config.clientApiBpUrl,
+      clientApiTxUrl: config.clientApiTxUrl,
       ethereumPrivateKey: config.ethereumPrivateKey,
       nightfallMnemonic: config.nightfallMnemonic,
     });

--- a/libs/client/client.ts
+++ b/libs/client/client.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import axios from "axios";
-import type { Commitment, UnspentCommitment } from "../nightfall/types";
+import type { Commitment, TransactionInfo, UnspentCommitment } from "../nightfall/types";
 import { logger, NightfallSdkError } from "../utils";
 import type { NightfallZkpKeys } from "../nightfall/types";
 import type { RecipientNightfallData } from "libs/transactions/types";
@@ -594,6 +594,36 @@ class Client {
 
     return res.data;
   }
+
+    /**
+   * Make GET request to get info about settled L2 transactions
+   *
+   * @async
+   * @method getTransactionsInfo
+   * @param {string[]} transactionHashes A list of L2 transacton hashes
+   * @throws {NightfallSdkError} Bad response
+   * @returns {Promise<TransactionInfo[]>}
+   */
+    async getTransactionsInfo(
+      transactionHashes: string[],
+    ): Promise<TransactionInfo[]> {
+      const endpoint = "transaction/info";
+      const apiUrl = this.apiTxUrl === "" ? this.apiUrl : this.apiTxUrl;
+      logger.debug({ endpoint }, "Calling client at");
+  
+      const res = await axios.get(`${apiUrl}/${endpoint}`, {
+        params: {
+          transactionHashes       
+        },
+      });
+      logger.info(
+        { status: res.status, data: res.data },
+        `Client at ${endpoint} responded`,
+      );
+  
+      return res.data.transactionsInfo;
+    }
+  
 }
 
 export default Client;

--- a/libs/client/client.ts
+++ b/libs/client/client.ts
@@ -611,11 +611,7 @@ class Client {
       const apiUrl = this.apiTxUrl === "" ? this.apiUrl : this.apiTxUrl;
       logger.debug({ endpoint }, "Calling client at");
   
-      const res = await axios.get(`${apiUrl}/${endpoint}`, {
-        params: {
-          transactionHashes       
-        },
-      });
+      const res = await axios.post(`${apiUrl}/${endpoint}`, { transactionHashes });
       logger.info(
         { status: res.status, data: res.data },
         `Client at ${endpoint} responded`,

--- a/libs/nightfall/types.ts
+++ b/libs/nightfall/types.ts
@@ -36,6 +36,13 @@ export interface UnspentCommitment {
   tokenId: string;
   hash: string;
 }
+
+export interface TransactionInfo {
+  blockNumber: string;
+  blockNumberL2: string;
+  transactionHash: string;
+  transactionHashL1: string;
+}
 export interface TransactionReceiptL2 {
   value: string;
   fee: string;

--- a/libs/user/types.ts
+++ b/libs/user/types.ts
@@ -71,6 +71,10 @@ export interface UserCheckBalances {
   tokenContractAddresses?: string[];
 }
 
+export interface UserGetTransactionsInfo {
+  transactionHashes?: string[];
+}
+
 export interface UserExportCommitments {
   listOfCompressedZkpPublicKey: string[];
   pathToExport: string;

--- a/libs/user/user.ts
+++ b/libs/user/user.ts
@@ -11,6 +11,7 @@ import {
   finaliseWithdrawalOptions,
   checkBalancesOptions,
   isInputValid,
+  transactionHashesOptions,
 } from "./validations";
 import { Client } from "../client";
 import {
@@ -47,10 +48,12 @@ import type {
   UserCheckBalances,
   UserExportCommitments,
   UserImportCommitments,
+  UserGetTransactionsInfo,
 } from "./types";
 import type {
   Commitment,
   NightfallZkpKeys,
+  TransactionInfo,
   UnspentCommitment,
 } from "../nightfall/types";
 import type { NightfallSDKTransactionReceipt } from "../transactions/types";
@@ -796,6 +799,38 @@ class User {
     return successMessage;
   }
 
+
+    /**
+   * Allow user to get all transactions info from settled l2  commitments
+   *
+   * @async
+   * @method getTransactionsInfo
+   * @param {UserGetTransactionsInfo} [options]
+   * @param {string[]} [options.tokenContractAddresses] A list of token addresses
+   * @returns {Promise<Record<string, TransactionInfo[]>>}
+   */
+    async getTransactionsInfo(
+      options?: UserGetTransactionsInfo,
+    ): Promise<TransactionInfo[]> {
+      logger.debug("User :: getTransactionsInfo");
+  
+      let transactionHashes: string[] = [];
+  
+      // If options were passed, validate and format
+      if (options) {
+        const { error, value } = transactionHashesOptions.validate(options);
+        isInputValid(error);
+        transactionHashes = value.transactionHashes;
+      }
+      logger.debug(
+        { transactionHashes },
+        "Get transaction info for transaction hashes",
+      );
+      return this.client.getTransactionsInfo(
+        transactionHashes,
+      );
+    }
+  
   /**
    * Close user blockchain ws connection
    * Use carefully: closing the ws too soon can result in errors,

--- a/libs/user/validations.ts
+++ b/libs/user/validations.ts
@@ -118,6 +118,10 @@ export const checkBalancesOptions = Joi.object({
   tokenContractAddresses: Joi.array().items(Joi.string().trim()),
 });
 
+export const transactionHashesOptions = Joi.object({
+  transactionHashes: Joi.array().items(Joi.string().trim()),
+});
+
 export function isInputValid(error: ValidationError | undefined) {
   if (error !== undefined) {
     const message = error.details.map((e) => e.message).join();

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eg:ganache:deposit": "ts-node -r dotenv/config examples/scripts/txDeposit.ts dotenv_config_path=./examples/scripts/.env.ganache dotenv_config_debug=true",
     "eg:ganache:minting": "ts-node -r dotenv/config examples/scripts/l2TokenisationMinting.ts dotenv_config_path=./examples/scripts/.env.ganache",
     "eg:ganache:transfer": "ts-node -r dotenv/config examples/scripts/txTransfer.ts dotenv_config_path=./examples/scripts/.env.ganache",
+    "eg:ganache:transactions-info": "ts-node -r dotenv/config examples/scripts/transactionsInfo.ts dotenv_config_path=./examples/scripts/.env.ganache",
     "eg:ganache:burning": "ts-node -r dotenv/config examples/scripts/l2TokenisationBurning.ts dotenv_config_path=./examples/scripts/.env.ganache",
     "eg:ganache:withdrawal": "ts-node -r dotenv/config examples/scripts/txWithdrawal.ts dotenv_config_path=./examples/scripts/.env.ganache",
     "eg:ganache:finalise-withdrawal": "ts-node -r dotenv/config examples/scripts/txWithdrawalFinalise.ts dotenv_config_path=./examples/scripts/.env.ganache",


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
- Get transactions info from client passing a list of transaction hashes.
- Fix examples with parameters for client workers

## Does this close any currently open issues?
No

## What commands can I run to test the change? 
```
npm run eg:ganache:transactions-info
```

## Any other comments?
